### PR TITLE
Allow beforeStart callback to make dragtable temporarily do nothing on mousedown

### DIFF
--- a/jquery.dragtable.js
+++ b/jquery.dragtable.js
@@ -331,11 +331,13 @@
       }
       var _this = this;
       this.bindTo.mousedown(function(evt) {
+        if (_this.options.beforeStart(this.originalTable) === false) {
+          return;
+        }
         clearTimeout(this.downTimer);
         this.downTimer = setTimeout(function() {
           _this.originalTable.selectedHandle = $(this);
           _this.originalTable.selectedHandle.addClass('dragtable-handle-selected');
-          _this.options.beforeStart(this.originalTable);
           _this._generateSortable(evt);
         }, _this.options.clickDelay);
       }).mouseup(function(evt) {


### PR DESCRIPTION
We're using this to disable dragging when a user is in-place editing a text field in the header
of the draggable table.  Without this, if they try to select their text, the table column
will drag and show a cloned empty text field.  Instead, with this, while they are editing,
the dragging is turned off.

Existing client code may be using your beforeStart callback to do very different things, so there is probably a better way to indicate temporary disablement.  Maybe if the table has a certain configurable class, it will ignore mousedown events.

Let me know what you think is the best way to achieve this.

Thanks
-Bill
