### PR TITLE
Fixed the situation where table header had other li elements in the table

### DIFF
--- a/jquery.dragtable.js
+++ b/jquery.dragtable.js
@@ -331,11 +331,13 @@
       }
       var _this = this;
       this.bindTo.mousedown(function(evt) {
+        if (_this.options.beforeStart(this.originalTable) === false) {
+          return;
+        }
         clearTimeout(this.downTimer);
         this.downTimer = setTimeout(function() {
           _this.originalTable.selectedHandle = $(this);
           _this.originalTable.selectedHandle.addClass('dragtable-handle-selected');
-          _this.options.beforeStart(this.originalTable);
           _this._generateSortable(evt);
         }, _this.options.clickDelay);
       }).mouseup(function(evt) {


### PR DESCRIPTION
Hello,

Thank you for your fantastic plugin. It helped us greatly. We just found a situation where we had 'li' in one of our table headers, which was interfering in the startIndex and endIndex calculations. We changed the code to look for li that are direct descendants only.

Thanks
Vidya Mani
