### PR TITLE
Fix wrong behaviour on tables with multiple column widths

### DIFF
--- a/jquery.dragtable.js
+++ b/jquery.dragtable.js
@@ -69,7 +69,7 @@
       cursorAt: false,             // @see http://api.jqueryui.com/sortable/#option-cursorAt
       distance: 0,                 // @see http://api.jqueryui.com/sortable/#option-distance, for immediate feedback use "0"
       tolerance: 'pointer',        // @see http://api.jqueryui.com/sortable/#option-tolerance
-      axis: 'x',                   // @see http://api.jqueryui.com/sortable/#option-axis, Only vertical moving is allowed. Use 'x' or null. Use this in conjunction with the 'containment' setting  
+      axis: 'x',                   // @see http://api.jqueryui.com/sortable/#option-axis, Only vertical moving is allowed. Use 'x' or null. Use this in conjunction with the 'containment' setting
       beforeStart: $.noop,         // returning FALSE will stop the execution chain.
       beforeMoving: $.noop,
       beforeReorganize: $.noop,
@@ -229,7 +229,7 @@
       var sortableHtml = '<ul class="dragtable-sortable" style="position:absolute; width:' + totalWidth + 'px;">';
       // assemble the needed html
       thtb.find('> tr > th').each(function(i, v) {
-        sortableHtml += '<li>';
+        sortableHtml += '<li style="width: ' + widthArr[i] + 'px;">';
         sortableHtml += '<table ' + attrsString + '>';
         var row = thtb.find('> tr > th:nth-child(' + (i + 1) + ')');
         if (_this.options.maxMovingRows > 1) {
@@ -251,7 +251,7 @@
       this.sortableTable.el = this.originalTable.el.before(sortableHtml).prev();
       // set width if necessary
       this.sortableTable.el.find('> li > table').each(function(i, v) {
-        var _this = $(this); 
+        var _this = $(this);
         if (widthArr[i] < _this.width()) {
           _this.css('width', widthArr[i] + 'px');
         }


### PR DESCRIPTION
To preserve the size of the column, I added the width of the original column
to de `li`.

I tested it on safari, firefox, and chrome and works well.

If you want, I can write a little demo of this for the demo page.

Thanks for the lib!
