### PR TITLE
Fix setting width of draggable table columns

### DIFF
--- a/jquery.dragtable.js
+++ b/jquery.dragtable.js
@@ -252,7 +252,7 @@
       // set width if necessary
       this.sortableTable.el.find('> li > table').each(function(i, v) {
         var _this = $(this); 
-        if (widthArr[i] < _this.width()) {
+        if (_this.width() < widthArr[i]) {
           _this.css('width', widthArr[i] + 'px');
         }
       });


### PR DESCRIPTION
The width of a draggable column was only explicitly set when the new column was wider than the original. I can imagine cases where the new column is too wide, though i'd have thought there would be more instances in which the new column would be smaller than the original one. 

Looking through git history (commit 36fb303a273ccc3dc8925e973e486439cdf3f08d), the changing of this comparison doesn't seem like it was intentional.
