### PR TITLE
Added left offset in dragtable-sortable ul

### DIFF
--- a/jquery.dragtable.js
+++ b/jquery.dragtable.js
@@ -232,7 +232,7 @@
       // one extra px on right and left side
       totalWidth += 2
 
-      var sortableHtml = '<ul class="dragtable-sortable" style="position:absolute; width:' + totalWidth + 'px;">';
+      var sortableHtml = '<ul class="dragtable-sortable" style="position:absolute; left:' + _this.originalTable.el.offset().left + 'px; ' width:' + totalWidth + 'px;">';
       // assemble the needed html
       thtb.find('> tr > th').each(function(i, v) {
         sortableHtml += '<li>';


### PR DESCRIPTION
If for example, we have a table that is horizontally centered

table{
width: 97%;
margin: 0px auto 0px auto;
}

we want to add left offset in dragtable-sortable ul. That way the ul dragtable-sortable does not stick on the left of the browser while dragging.
