### PR TITLE
Allow drag only by using the left mouse button

### DIFF
--- a/jquery.dragtable.js
+++ b/jquery.dragtable.js
@@ -330,6 +330,9 @@
       }
       var _this = this;
       this.bindTo.mousedown(function(evt) {
+        
+        if(evt.which!==1) return;
+        
         if (_this.options.beforeStart(this.originalTable) === false) {
           return;
         }


### PR DESCRIPTION
Allow drag only by using the left mouse button.

Perhaps this should be set as an option so the user can select which keys trigger drag.
