### PR TITLE
Implemented mouse events with jQuery UI Mouse

### DIFF
--- a/jquery.dragtable.js
+++ b/jquery.dragtable.js
@@ -53,7 +53,7 @@
  */
 
 (function($) {
-  $.widget("akottr.dragtable", {
+  $.widget("akottr.dragtable", $.ui.mouse, {
     options: {
       revert: false,               // smooth revert
       dragHandle: '.table-handle', // handle for moving cols, if not exists the whole 'th' is the handle
@@ -328,29 +328,34 @@
       if (this.options.restoreState !== null) {
         $.isFunction(this.options.restoreState) ? this.options.restoreState(this.originalTable) : this._restoreState(this.options.restoreState);
       }
-      var _this = this;
-      this.bindTo.mousedown(function(evt) {
-        // listen only to left mouse click
-        if(evt.which!==1) return;
-        if (_this.options.beforeStart(_this.originalTable) === false) {
-          return;
+      this._mouseInit();
+    },
+    _mouseDown: function (evt) {
+        if (!(this.bindTo.is(evt.originalEvent.srcElement) || this.bindTo.find(evt.originalEvent.srcElement).length > 0)) {
+            return;
         }
+
+        if (this.options.beforeStart(this.originalTable) === false) {
+            return;
+        }
+
         clearTimeout(this.downTimer);
+        var _this = this;
         this.downTimer = setTimeout(function() {
-          _this.originalTable.selectedHandle = $(this);
-          _this.originalTable.selectedHandle.addClass('dragtable-handle-selected');
-          _this._generateSortable(evt);
+            _this.originalTable.selectedHandle = $(this);
+            _this.originalTable.selectedHandle.addClass('dragtable-handle-selected');
+            _this._generateSortable(evt);
         }, _this.options.clickDelay);
-      }).mouseup(function(evt) {
-        clearTimeout(this.downTimer);
-      });
+    },
+    _mouseStop: function () {
+        clearTimeout(this.downTimer);    
     },
     redraw: function(){
       this.destroy();
       this._create();
     },
     destroy: function() {
-      this.bindTo.unbind('mousedown');
+      this._mouseDestroy();
       $.Widget.prototype.destroy.apply(this, arguments); // default destroy
       // now do other stuff particular to this widget
     }


### PR DESCRIPTION
By using jQuery UI Mouse instead of the "native" mouse events there's an easy way to make it work on touchscreens with jQuery UI Touch Punch.

There's no new dependency as jQuery UI Draggable already uses jQuery UI Mouse.
