### PR TITLE
reduced int parsing to persistObj[n] in _restoreState function

### DIFF
--- a/jquery.dragtable.js
+++ b/jquery.dragtable.js
@@ -109,7 +109,7 @@
     _restoreState: function(persistObj) {
       for (var n in persistObj) {
         this.originalTable.startIndex = $('#' + n).closest('th').prevAll().size() + 1;
-        this.originalTable.endIndex = parseInt(persistObj[n] + 1, 10);
+        this.originalTable.endIndex = parseInt(persistObj[n], 10) + 1;
         this._bubbleCols();
       }
     },


### PR DESCRIPTION
Comment above _restoreState function suggests that persist object is something like: {'id1':'2','id3':'3','id2':'1'} where column indexes are strings. This causes error 'TypeError: b is undefined' because for 'id1' it concatenates string index '2' with 1 getting '21' which is parsed to 21 instead of 2+1=3 and so on... please apply this fix or change example persist object in comment above _restoreState to {'id1':2,'id3':3,'id2':1}
