### PR TITLE
Add package.json and some fixes

### DIFF
--- a/dragtable.css
+++ b/dragtable.css
@@ -18,10 +18,6 @@
     border-left: 0px;
 }
 
-.dragtable-sortable li:first-child th, .dragtable-sortable li:first-child td {
-    border-left: 1px solid #CCC; 
-}
-
 .ui-sortable-helper {
     opacity: 0.7;filter: alpha(opacity=70);
 }

--- a/jquery.dragtable.js
+++ b/jquery.dragtable.js
@@ -238,7 +238,7 @@
         var width_li = $(this).is(':visible') ? $(this).outerWidth() : 0;
         sortableHtml += '<li style="width:' + width_li + 'px;">';
         sortableHtml += '<table ' + attrsString + '>';
-        var row = thtb.find('> tr > th:nth-child(' + (i + 1) + ')');
+        var row = thtb.find('> tr > th:nth-child(' + (i + 1) + '):visible');
         if (_this.options.maxMovingRows > 1) {
           row = row.add(thtb.find('> tr > td:nth-child(' + (i + 1) + ')').slice(0, _this.options.maxMovingRows - 1));
         }

--- a/jquery.dragtable.js
+++ b/jquery.dragtable.js
@@ -333,7 +333,7 @@
       this.bindTo.mousedown(function(evt) {
         // listen only to left mouse click
         if(evt.which!==1) return;
-        if (_this.options.beforeStart(_this.originalTable) === false) {
+        if (_this.options.beforeStart(_this.originalTable, evt) === false) {
           return;
         }
         clearTimeout(this.downTimer);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "dragtable",
+  "version": "2.0.15",
+  "description": "A draggable column table plugin for jquery.",
+  "main": "jquery.dragtable.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/akottr/dragtable.git"
+  },
+  "author": "Andres <akottr@gmail.com>",
+  "license": "MIT GPL",
+  "bugs": {
+    "url": "https://github.com/akottr/dragtable/issues"
+  },
+  "homepage": "http://akottr.github.io/dragtable",
+  "keywords": [
+    "table",
+    "jquery",
+    "draggable"
+  ],
+  "dependencies": {
+    "jquery": "*",
+    "jquery-ui": "1.11.*"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,8 +20,5 @@
     "table",
     "jquery",
     "draggable"
-  ],
-  "dependencies": {
-    "jquery": "~2.1.1"
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "draggable"
   ],
   "dependencies": {
-    "jquery": "~2.1.1",
-    "jquery-ui": "~1.11.4"
+    "jquery": "~2.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "draggable"
   ],
   "dependencies": {
-    "jquery": "*",
-    "jquery-ui": "1.11.*"
+    "jquery": "~2.1.1",
+    "jquery-ui": "~1.11.4"
   }
 }


### PR DESCRIPTION
Apart from adding package.json file:

- Consider just visible headers when cloning the header template for adding to the virtual ul.
- Remove css class to avoid forcing a style for the virtual ul, since it may get different from the original table.